### PR TITLE
Update links to archived articles on the medium freecodecamp account

### DIFF
--- a/src/components/about-me.js
+++ b/src/components/about-me.js
@@ -29,7 +29,7 @@ const AboutMe = ({ profileImg, hobbyImgs }) => {
             <p>
               I recently{" "}
               <a
-                href="https://medium.freecodecamp.org/my-journey-to-becoming-a-software-engineer-4ae301fc02b"
+                href="https://medium.com/free-code-camp/my-journey-to-becoming-a-software-engineer-4ae301fc02b"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -37,7 +37,7 @@ const AboutMe = ({ profileImg, hobbyImgs }) => {
               </a>
               ,{" "}
               <a
-                href="https://medium.freecodecamp.org/how-i-made-my-portfolio-website-blazing-fast-with-gatsby-82ccddc2f671"
+                href="https://medium.com/free-code-camp/how-i-made-my-portfolio-website-blazing-fast-with-gatsby-82ccddc2f671"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
Links using the domain medium.freecodecamp.org will reroute to freecodcamp's news website. Updating the links to point to FreeCodeCamp's archived articles on Medium because the code for the Gatsby article is showing properly on Medium, but not on FCC. This is pretty important because the code is an important part of this article to be impactful. There are also many comments on the Medium website that I would love for others to see. I will be moving away from Medium for technical blog posts, but for now keeping these articles to be viewed on Medium. 