### PR TITLE
A11y: Update Color Contrast

### DIFF
--- a/src/components/cover.css
+++ b/src/components/cover.css
@@ -1,7 +1,7 @@
 .cover {
   width: 100%;
   height: 100vh;
-  background-color: white;
+  background-color: #265a87;
   position: relative;
 }
 

--- a/src/components/footer.css
+++ b/src/components/footer.css
@@ -8,6 +8,6 @@ footer {
   text-align: center;
   bottom: 0;
   left: 0;
-  background-color: gray;
+  background-color: #595959;
   color: white;
 }


### PR DESCRIPTION
## Description
Failing A11y Check : "Background and foreground colors do not have a sufficient contrast ratio"

What this means: Some people may have a hard time reading the text in the page if the text brightness is too close to the background brightness. This issue can affect everyone. From people with low vision, color blindness, and even for users who reading something on their phone outside in the sun.

Resource: [html Element does not have a lang attribute](https://web.dev/html-has-lang/?utm_source=lighthouse&utm_medium=devtools)

## Root Cause
Hadn't checked contrast ratio on webpage.

## Solution
Used the contrast tab in the [Wave Tool](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh?hl=en-US) to find failling contrast area in page. Used the contrast tool to find a good background color for my cover image as well as my footer that would improve the contrast ratio.

Also used https://www.brandwood.com/a11y/ to test that contrast between the text area and the background image.

- [x] Made the footer background a bit darker. 

- [x] Added a background color to the cover section in case the background image didn't load. Before I had the background color set to white and the cover image color was also set to white. What would happen if the image didn't load? The  overlay color would not have enough contrast from the white text. 

## Screenshots

Footer color update (Darker background for better contrast):
<img width="350" alt="FooterUpdate" src="https://user-images.githubusercontent.com/15005856/87882993-f2a0a080-c9b8-11ea-88ba-128c3d052f5a.png">

Added a blue background color to the cover section in case the cover image doesn't load. Before the background color was white. If the cover image didn't load, the white text in the cover would not have enough contrast between the overlay color. 

<img width="350" alt="BGBackgroundCoverImg" src="https://user-images.githubusercontent.com/15005856/87883189-9474bd00-c9ba-11ea-983b-a60de57c3ab1.png">




## Resources
 [Background and foreground colors do not have a sufficient contrast ratio](https://web.dev/color-contrast/?utm_source=lighthouse&utm_medium=devtools)


