### PR TITLE
A11y: Set a default language

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -22,6 +22,7 @@ const HomePage = ({ data }) => {
         <title>{siteTitle}</title>
         <meta name="description" content={metaDescr} />
         <link rel="icon" type="/image/png" href={favicon} />
+        <html lang="en" />
       </Helmet>
       <Cover coverImg={data.coverImg} />
       <div className="container-fluid main">


### PR DESCRIPTION
## Description
Failing A11y Check in Lighthouse: "HTML element does not have a lang attribute"

What this means: If a page doesn't specify the main language of the document's content (technically speaking, not specifying a lang attribute), a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly sometimes making it impossible to understand the content.

Resource: [html Element does not have a lang attribute](https://web.dev/html-has-lang/?utm_source=lighthouse&utm_medium=devtools)

## Root Cause
There is no set 'lang' attribute in the html head tag.

## Solution
We are using React Helmet to manage dynamically set contents of the head element. 
Added the html element with a set language into the Helmet component. 

Resource: [How to Resolve Accessibility Issues with React Helmet](https://www.dslemay.com/blog/2019/05/28/how-to-resolve-accessibility-issues-with-react-helmet)
